### PR TITLE
Point to forecasts paper in the README...

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2019, Simons Observatory
+Copyright (c) 2019-2020, Simons Observatory
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,19 @@ available here, to supplement published projections and simulations.
 This main home of the repository is:
 https://github.com/simonsobs/so_noise_models.
 
-The repository is organized as follows:
+The noise model was originally described and applied in the
+publication:
+
+  Simons Observatory Collaboration.  "The Simons Observatory: science
+  goals and forecasts".  JCAP 1902 (2019) 056.  arxiv:1808.07455
+
+The paper may be found at the following links:
+
+- https://dx.doi.org/10.1088/1475-7516/2019/02/056
+- https://arxiv.org/abs/1808.07445
+
+
+This repository is organized as follows:
 
 - ``so_models_v3/``: Python 3 package providing the noise model code
   used in publications and publicly released simulations.  This

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='so_noise_models',
-      version='3.1.0',
+      version='3.1.1',
       description='Simons Observatory N(ell) noise models for public release',
       author='Simons Observatory Collaboration',
       author_email='so_tac@simonsobservatory.org',


### PR DESCRIPTION
... addressing issue #4.  Also bump version in setup.py; add 2020 to
the LICENSE.

If anyone has a preferred way to format references like the one in the README... please fix it.